### PR TITLE
Add Unity setup confirmation for PixDash

### DIFF
--- a/contributors/A9922524003889(el).txt
+++ b/contributors/A9922524003889(el).txt
@@ -1,3 +1,4 @@
 Name: Prajjawal Vaishya
 GitHub Username: Prajjawal-Vaishya
 Favorite game: Tekken 8
+Screenshot Link: https://drive.google.com/file/d/19HfclKkBR_-csRRX15s1tS25_hsgaGCn/view?usp=sharing


### PR DESCRIPTION
Issue: #27 

Installed Unity 6.3 LTS (6000.3.2f1) and successfully opened the PixDash project in Unity Hub. Added screenshot link in contributors/A9922524003889(el).txt as setup confirmation.
